### PR TITLE
Fix local config for OAS discovery

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -66,7 +66,7 @@ microservice {
       port     = 8470
     }
 
-    oas-discovery {
+    oas-discovery-api {
       host = localhost
       port = 15024
       path = oas-discovery-stubs


### PR DESCRIPTION
OAS discovery stubs is under the wrong config key and needs to be fixed for autopublish to work