### PR TITLE
Optional deployment timestamp

### DIFF
--- a/app/uk/gov/hmrc/integrationcatalogueautopublish/models/ApiDeployment.scala
+++ b/app/uk/gov/hmrc/integrationcatalogueautopublish/models/ApiDeployment.scala
@@ -20,7 +20,7 @@ import play.api.libs.json.{Format, Json}
 
 import java.time.Instant
 
-case class ApiDeployment(id: String, deploymentTimestamp: Instant)
+case class ApiDeployment(id: String, deploymentTimestamp: Option[Instant])
 
 object ApiDeployment {
 

--- a/it/test/uk/gov/hmrc/integrationcatalogueautopublish/connectors/OasDiscoveryApiConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/integrationcatalogueautopublish/connectors/OasDiscoveryApiConnectorSpec.scala
@@ -211,6 +211,10 @@ object OasDiscoveryApiConnectorSpec {
   private val oasDiscoveryAuth = s"Basic ${Base64.getEncoder.encodeToString(s"$testClientId:$testSecret".getBytes("UTF-8"))}"
   private val deploymentId1 = UUID.randomUUID().toString
   private val deploymentId2 = UUID.randomUUID().toString
-  private val someDeployments = Seq(ApiDeployment(deploymentId1, Instant.now()), ApiDeployment(deploymentId2, Instant.now()))
+
+  private val someDeployments = Seq(
+    ApiDeployment(deploymentId1, Some(Instant.now())),
+    ApiDeployment(deploymentId2, Some(Instant.now()))
+  )
 
 }


### PR DESCRIPTION
We have found that the deployment timestamp can be null in the response from APIM. Change the model so the attribute os optional. Do not process deployments without a timestamp.